### PR TITLE
fix: change image name of the spring app.

### DIFF
--- a/blog/docker-compose.yml
+++ b/blog/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - mysql_data:/var/lib/mysql
 
   spring-boot-app:
-    image: husseinokasha/blog
+    image: blog
     ports:
       - "8080:8080"
     networks:


### PR DESCRIPTION
- Previously, I relied on dockerhub to get the image contianing my spring app so it's name was "husseinokasha/blog"
- Now, I build the image locally so the name is "blog"