### PR TITLE
docs: fix create post and list posts commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ I have a user created under email: "f1@gmail.com", password: "123" owning one po
 * In case of failed login, returns status code 401 unauthorized.
 
 ### Create Post
-* `curl -X POST \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer token" \
-  -d '{"body": "f2 first post"}' \
-  http://localhost:8080/api/posts
+* `curl -X POST
+-H "Content-Type: application/json"
+-H "Authorization: Bearer token"
+-d '{"body": "f2 first post"}'
+http://localhost:8080/api/posts
   `
 * Replace "token" in the command with the token you got after a sucessfull login.
 * Along with authorization header containing a valid bearer token, and the post body it will return status code
@@ -62,9 +62,9 @@ I have a user created under email: "f1@gmail.com", password: "123" owning one po
 * In case the user embedded in the bearer token doesn't exist it will return status code 401 unauthorized
 
 ### List your posts
-* `curl -H "Content-Type: application/json" \
-  -H "Authorization: Bearer token" \
-  http://localhost:8080/api/posts
+* `curl -H "Content-Type: application/json"
+-H "Authorization: Bearer token"
+http://localhost:8080/api/posts
   `
 * Replace "token" in the command with the token you got after a sucessfull login.
 * Along with authorization header containing a valid bearer token, it will return all posts of the user 


### PR DESCRIPTION
- remove '\' this character which I use to make multiline curl commands.
- md formating doesn't respect this and adds spaces after '\' which causes errors when running the commands.
- it works fine in the row file but when it is presented this error happens.
- so I removed that character from my commands.